### PR TITLE
Add OEMSETUP.INF

### DIFF
--- a/OEMSETUP.INF
+++ b/OEMSETUP.INF
@@ -1,0 +1,200 @@
+; ---------------------------------------------------------------
+; Modern Generic SVGA driver
+; Copyright 2025 Michael Keyes
+; ---------------------------------------------------------------
+
+[data]
+    Version="3.10"
+
+[disks]
+    1 =. ,"Microsoft Windows 3.1 Disk #1",disk1
+    2 =. ,"Microsoft Windows 3.1 Disk #2",disk2
+    5 =. ,"Microsoft Windows 3.1 Disk #5",disk5
+[oemdisks]
+    V =.,  "Modern Generic SVGA driver", vbesvgadisk
+
+[display]
+;profile      = driver,        Description of driver,                     resolution,    286 grabber,    logo code,     VDD,           386grabber, ega.sys, logo data,     optional work section
+vbesvga640    = V:vbesvga.drv, "Modern Generic SVGA   640x480 256 colors", "100,96,96",   2:vgacolor.2gr, 2:vgalogo.lgo, V:vddvbe.386,  2:vgadib.3gr,,       2:vgalogo.rle,  vbe640
+vbesvga600l   = V:vbesvga.drv, "Modern Generic SVGA   800x600 256 Large" , "100,120,120", 2:vgacolor.2gr, 2:vgalogo.lgo, V:vddvbe.386,  2:vgadib.3gr,,       2:vgalogo.rle,  vbe800l
+vbesvga600s   = V:vbesvga.drv, "Modern Generic SVGA   800x600 256 Small" , "100,96,96",   2:vgacolor.2gr, 2:vgalogo.lgo, V:vddvbe.386,  2:vgadib.3gr,,       2:vgalogo.rle,  vbe800s
+vbesvga768l   = V:vbesvga.drv, "Modern Generic SVGA  1024x768 256 Large" , "100,120,120", 2:vgacolor.2gr, 2:vgalogo.lgo, V:vddvbe.386,  2:vgadib.3gr,,       2:vgalogo.rle,  vbe768l
+vbesvga768s   = V:vbesvga.drv, "Modern Generic SVGA  1024x768 256 Small" , "100,96,96",   2:vgacolor.2gr, 2:vgalogo.lgo, V:vddvbe.386,  2:vgadib.3gr,,       2:vgalogo.rle,  vbe768s
+vbesvga1024s  = V:vbesvga.drv, "Modern Generic SVGA 1280x1024 256 Large" , "100,120,120", 2:vgacolor.2gr, 2:vgalogo.lgo, V:vddvbe.386,  2:vgadib.3gr,,       2:vgalogo.rle,  vbe1024l
+vbesvga1024s  = V:vbesvga.drv, "Modern Generic SVGA 1280x1024 256 Small" , "100,96,96",   2:vgacolor.2gr, 2:vgalogo.lgo, V:vddvbe.386,  2:vgadib.3gr,,       2:vgalogo.rle,  vbe1024s
+vbesvga1200s  = V:vbesvga.drv, "Modern Generic SVGA 1600x1200 256 Large" , "100,120,120", 2:vgacolor.2gr, 2:vgalogo.lgo, V:vddvbe.386,  2:vgadib.3gr,,       2:vgalogo.rle,  vbe1200l
+vbesvga1200s  = V:vbesvga.drv, "Modern Generic SVGA 1600x1200 256 Small" , "100,96,96",   2:vgacolor.2gr, 2:vgalogo.lgo, V:vddvbe.386,  2:vgadib.3gr,,       2:vgalogo.rle,  vbe1200s
+vbesvga640hi  = V:vbesvga.drv, "Modern Generic SVGA   640x480 65k colors", "100,96,96",   2:vgacolor.2gr, 2:vgalogo.lgo, V:vddvbe.386,  2:vgadib.3gr,,       2:vgalogo.rle,  vbehi640
+vbesvga600lhi = V:vbesvga.drv, "Modern Generic SVGA   800x600 65k Large" , "100,120,120", 2:vgacolor.2gr, 2:vgalogo.lgo, V:vddvbe.386,  2:vgadib.3gr,,       2:vgalogo.rle,  vbehi800l
+vbesvga600shi = V:vbesvga.drv, "Modern Generic SVGA   800x600 65k Small" , "100,96,96",   2:vgacolor.2gr, 2:vgalogo.lgo, V:vddvbe.386,  2:vgadib.3gr,,       2:vgalogo.rle,  vbehi800s
+vbesvga768lhi = V:vbesvga.drv, "Modern Generic SVGA  1024x768 65k Large" , "100,120,120", 2:vgacolor.2gr, 2:vgalogo.lgo, V:vddvbe.386,  2:vgadib.3gr,,       2:vgalogo.rle,  vbehi768l
+vbesvga768shi = V:vbesvga.drv, "Modern Generic SVGA  1024x768 65k Small" , "100,96,96",   2:vgacolor.2gr, 2:vgalogo.lgo, V:vddvbe.386,  2:vgadib.3gr,,       2:vgalogo.rle,  vbehi768s
+vbesvga640tr  = V:vbesvga.drv, "Modern Generic SVGA   640x480 16M colors", "100,96,96",   2:vgacolor.2gr, 2:vgalogo.lgo, V:vddvbe.386,  2:vgadib.3gr,,       2:vgalogo.rle,  vbetr640
+vbesvga600ltr = V:vbesvga.drv, "Modern Generic SVGA   800x600 16M Large" , "100,120,120", 2:vgacolor.2gr, 2:vgalogo.lgo, V:vddvbe.386,  2:vgadib.3gr,,       2:vgalogo.rle,  vbetr800l
+vbesvga600str = V:vbesvga.drv, "Modern Generic SVGA   800x600 16M Small" , "100,96,96",   2:vgacolor.2gr, 2:vgalogo.lgo, V:vddvbe.386,  2:vgadib.3gr,,       2:vgalogo.rle,  vbetr800s
+vbesvga768ltr = V:vbesvga.drv, "Modern Generic SVGA  1024x768 16M Large" , "100,120,120", 2:vgacolor.2gr, 2:vgalogo.lgo, V:vddvbe.386,  2:vgadib.3gr,,       2:vgalogo.rle,  vbetr768l
+vbesvga768str = V:vbesvga.drv, "Modern Generic SVGA  1024x768 16M Small" , "100,96,96",   2:vgacolor.2gr, 2:vgalogo.lgo, V:vddvbe.386,  2:vgadib.3gr,,       2:vgalogo.rle,  vbetr768s
+
+[vbe640]
+,,system.ini,vbesvga.drv,"Width=","Width=640"
+,,system.ini,vbesvga.drv,"Height","Height=480"
+,,system.ini,vbesvga.drv,"Depth","Depth=8"
+
+[vbe800s]
+,,system.ini,vbesvga.drv,"Width=","Width=800"
+,,system.ini,vbesvga.drv,"Height","Height=600"
+,,system.ini,vbesvga.drv,"Depth","Depth=8"
+,,system.ini,vbesvga.drv,"fontsize","fontsize=small"
+
+[vbe800l] 
+,,system.ini,vbesvga.drv,"Width=","Width=800"
+,,system.ini,vbesvga.drv,"Height","Height=600"
+,,system.ini,vbesvga.drv,"Depth","Depth=8"
+,,system.ini,vbesvga.drv,"fontsize","fontsize=large"
+
+[vbe768s]
+,,system.ini,vbesvga.drv,"Width=","Width=1024"
+,,system.ini,vbesvga.drv,"Height","Height=768"
+,,system.ini,vbesvga.drv,"Depth","Depth=8"
+,,system.ini,vbesvga.drv,"fontsize","fontsize=small"
+
+[vbe768l] 
+,,system.ini,vbesvga.drv,"Width=","Width=1024"
+,,system.ini,vbesvga.drv,"Height","Height=768"
+,,system.ini,vbesvga.drv,"Depth","Depth=8"
+,,system.ini,vbesvga.drv,"fontsize","fontsize=large"
+
+[vbe1024s]
+,,system.ini,vbesvga.drv,"Width=","Width=1280"
+,,system.ini,vbesvga.drv,"Height","Height=1024"
+,,system.ini,vbesvga.drv,"Depth","Depth=8"
+,,system.ini,vbesvga.drv,"fontsize","fontsize=small"
+
+[vbe1024l] 
+,,system.ini,vbesvga.drv,"Width=","Width=1280"
+,,system.ini,vbesvga.drv,"Height","Height=1024"
+,,system.ini,vbesvga.drv,"Depth","Depth=8"
+,,system.ini,vbesvga.drv,"fontsize","fontsize=large"
+
+[vbe1200s]
+,,system.ini,vbesvga.drv,"Width=","Width=1600"
+,,system.ini,vbesvga.drv,"Height","Height=1200"
+,,system.ini,vbesvga.drv,"Depth","Depth=8"
+,,system.ini,vbesvga.drv,"fontsize","fontsize=small"
+
+[vbe1200l] 
+,,system.ini,vbesvga.drv,"Width=","Width=1600"
+,,system.ini,vbesvga.drv,"Height","Height=1200"
+,,system.ini,vbesvga.drv,"Depth","Depth=8"
+,,system.ini,vbesvga.drv,"fontsize","fontsize=large"
+
+[vbehi640]
+,,system.ini,vbesvga.drv,"Width=","Width=640"
+,,system.ini,vbesvga.drv,"Height","Height=480"
+,,system.ini,vbesvga.drv,"Depth","Depth=16"
+
+[vbehi800s]
+,,system.ini,vbesvga.drv,"Width=","Width=800"
+,,system.ini,vbesvga.drv,"Height","Height=600"
+,,system.ini,vbesvga.drv,"Depth","Depth=16"
+,,system.ini,vbesvga.drv,"fontsize","fontsize=small"
+
+[vbehi800l] 
+,,system.ini,vbesvga.drv,"Width=","Width=800"
+,,system.ini,vbesvga.drv,"Height","Height=600"
+,,system.ini,vbesvga.drv,"Depth","Depth=16"
+,,system.ini,vbesvga.drv,"fontsize","fontsize=large"
+
+[vbehi768s]
+,,system.ini,vbesvga.drv,"Width=","Width=1024"
+,,system.ini,vbesvga.drv,"Height","Height=768"
+,,system.ini,vbesvga.drv,"Depth","Depth=16"
+,,system.ini,vbesvga.drv,"fontsize","fontsize=small"
+
+[vbehi768l] 
+,,system.ini,vbesvga.drv,"Width=","Width=1024"
+,,system.ini,vbesvga.drv,"Height","Height=768"
+,,system.ini,vbesvga.drv,"Depth","Depth=16"
+,,system.ini,vbesvga.drv,"fontsize","fontsize=large"
+
+[vbehi1024s]
+,,system.ini,vbesvga.drv,"Width=","Width=1280"
+,,system.ini,vbesvga.drv,"Height","Height=1024"
+,,system.ini,vbesvga.drv,"Depth","Depth=16"
+,,system.ini,vbesvga.drv,"fontsize","fontsize=small"
+
+[vbehi1024l] 
+,,system.ini,vbesvga.drv,"Width=","Width=1280"
+,,system.ini,vbesvga.drv,"Height","Height=1024"
+,,system.ini,vbesvga.drv,"Depth","Depth=16"
+,,system.ini,vbesvga.drv,"fontsize","fontsize=large"
+
+[vbetr640]
+,,system.ini,vbesvga.drv,"Width=","Width=640"
+,,system.ini,vbesvga.drv,"Height","Height=480"
+,,system.ini,vbesvga.drv,"Depth","Depth=24"
+
+[vbetr800s]
+,,system.ini,vbesvga.drv,"Width=","Width=800"
+,,system.ini,vbesvga.drv,"Height","Height=600"
+,,system.ini,vbesvga.drv,"Depth","Depth=24"
+,,system.ini,vbesvga.drv,"fontsize","fontsize=small"
+
+[vbetr800l] 
+,,system.ini,vbesvga.drv,"Width=","Width=800"
+,,system.ini,vbesvga.drv,"Height","Height=600"
+,,system.ini,vbesvga.drv,"Depth","Depth=24"
+,,system.ini,vbesvga.drv,"fontsize","fontsize=large"
+
+[vbetr768s]
+,,system.ini,vbesvga.drv,"Width=","Width=1024"
+,,system.ini,vbesvga.drv,"Height","Height=768"
+,,system.ini,vbesvga.drv,"Depth","Depth=24"
+,,system.ini,vbesvga.drv,"fontsize","fontsize=small"
+
+[vbetr768l] 
+,,system.ini,vbesvga.drv,"Width=","Width=1024"
+,,system.ini,vbesvga.drv,"Height","Height=768"
+,,system.ini,vbesvga.drv,"Depth","Depth=24"
+,,system.ini,vbesvga.drv,"fontsize","fontsize=large"
+
+[vbetr1024s]
+,,system.ini,vbesvga.drv,"Width=","Width=1280"
+,,system.ini,vbesvga.drv,"Height","Height=1024"
+,,system.ini,vbesvga.drv,"Depth","Depth=24"
+,,system.ini,vbesvga.drv,"fontsize","fontsize=small"
+
+[vbetr1024l] 
+,,system.ini,vbesvga.drv,"Width=","Width=1280"
+,,system.ini,vbesvga.drv,"Height","Height=1024"
+,,system.ini,vbesvga.drv,"Depth","Depth=24"
+,,system.ini,vbesvga.drv,"fontsize","fontsize=large"
+
+[sysfonts]
+1:vgasys.fon,"VGA (640x480) resolution System Font", "100,96,96"
+1:8514sys.fon,"8514/a (1024x768) resolution System Font", "100,120,120"
+
+[fixedfonts]
+2:vgafix.fon,"VGA (640x480) resolution Fixed System Font", "100,96,96"
+2:8514fix.fon,"8514/a (1024x768) resolution Fixed System Font",  "100,120,120"
+
+[oemfonts]
+2:vgaoem.fon,"VGA (640x480) resolution Terminal Font (USA/Europe)", "100,96,96",1
+2:8514oem.fon,"8514/a (1024x768) resolution Terminal Font (USA/Europe)", "100,120,120",1
+
+[fonts]
+   5:SSERIFE.FON, "MS Sans Serif 8,10,12,14,18,24 (VGA res)", "100,96,96"
+   5:SSERIFF.FON, "MS Sans Serif 8,10,12,14,18,24 (8514/a res)", "100,120,120"
+
+   5:COURE.FON, "Courier 10,12,15 (VGA res)", "100,96,96"
+   5:COURF.FON, "Courier 10,12,15 (8514/a res)", "100,120,120"
+
+   5:SERIFE.FON, "MS Serif 8,10,12,14,18,24 (VGA res)", "100,96,96"
+   5:SERIFF.FON, "MS Serif 8,10,12,14,18,24 (8514/a res)", "100,120,120"
+
+   5:SYMBOLE.FON, "Symbol 8,10,12,14,18,24 (VGA res)", "100,96,96"
+   5:SYMBOLF.FON, "Symbol 8,10,12,14,18,24 (8514/a res)", "100,120,120"
+
+   5:SMALLE.FON, "Small Fonts (VGA res)", "100,96,96"
+   5:SMALLF.FON, "Small Fonts (8514/a res)", "100,120,120"
+


### PR DESCRIPTION
Here is a first proposal for an `OEMSETUP.INF`.

1. The modes included now are the ones exposed by DOSEMU2. I guess more modes had better be collected. I will add anything that is suggested.

2. Only the width, height, depth and font size are set. Maybe more variants for the other options would be useful. Maybe known working combinations that were tested with particular graphics hardware could be added under the name of that particular model. I tested these modes with DOSEMU2.

3. The location in this Git repo might not be optimal. @PluMGMK, I will move it to any spot you suggest :)

4. Multiple files referenced are actually on the Windows 3.1 installation disks. I referenced the actual disks (at least matching for the English version), but some of the Windows driver installation mechanisms are known to be buggy with switching disks. This is why many driver disks ended up including these files on them. Installing through the GUI should work and ask for the correct disks. Then switching from text mode and always keeping the current driver should work as well.